### PR TITLE
Added link to fh-sync-js to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A basic list application that uses the FeedHenry data synchronisation framework.
 
-This can be used in conjunction with the [FeedHenry Sync Server](https://github.com/feedhenry/fh-sync-server).
+This can be used in conjunction with the [FeedHenry Sync Server](https://github.com/feedhenry/fh-sync-server). The [fh-sync-js](https://github.com/feedhenry/fh-sync-js) library is used to connect to FeedHenry Sync Server.
 
 ## Running the app
 


### PR DESCRIPTION
Motivation

It's good to have links from one sync related repo to another. Having multiple unconnected repos is not a good user experience. Thus I added link to fh-sync-js repo to readme. This library is used for connecting to fh-sync-server (there is a link to this repo already).